### PR TITLE
Use option kwargs in simple_function

### DIFF
--- a/example_client/tools/simple_funcx_tool.py
+++ b/example_client/tools/simple_funcx_tool.py
@@ -1,10 +1,7 @@
 from gladier import GladierBaseTool, generate_flow_definition
 
-
-def simple_function(**data):
+def simple_function(wfile = None, text = None, **data):
     import os
-    wfile = data['file']
-    text = data['name']
 
     if '~' in wfile:
         wfile = os.path.expanduser(wfile)


### PR DESCRIPTION
In the simple funcx example, rather than just taking arbitrary
kwargs (as `**data`) and indexing into that, let python do the work by
defining the desired input arguments as kwargs with default
values. Then, continue to use **data so that any additional args don't
cause things to blow up.
