### PR TITLE
Remove unused components in the XPCS client module

### DIFF
--- a/paper_demo/tools/xpcs_boost_corr.py
+++ b/paper_demo/tools/xpcs_boost_corr.py
@@ -61,7 +61,7 @@ def xpcs_boost_corr(**data):
 
 
 @generate_flow_definition(modifiers={
-    xpcs_boost_corr: {'WaitTime': 7200}
+    xpcs_boost_corr: {'WaitTime': 7200, 'ExceptionOnActionFailure': True}
 })
 class BoostCorr(GladierBaseTool):
 

--- a/paper_demo/xpcs_client.py
+++ b/paper_demo/xpcs_client.py
@@ -1,28 +1,13 @@
-#!/usr/bin/env python
-
-# Enable Gladier Logging
-# import gladier.tests
-
 import argparse
 import os
-import pathlib
-
 
 from gladier import GladierBaseClient, generate_flow_definition
-
-##Import individual functions
-from tools.xpcs_pre_publish import PrePublish
 from tools.xpcs_boost_corr import BoostCorr
 from tools.xpcs_plot import MakeCorrPlots
-from tools.xpcs_gather_metadata import GatherXPCSMetadata
-from tools.xpcs_publish import Publish
 
 
-@generate_flow_definition(modifiers={
-#    'publish_gather_metadata': {'payload': '$.GatherXpcsMetadata.details.result[0]'}
-})
+@generate_flow_definition
 class XPCSBoost(GladierBaseClient):
-    globus_group = '368beb47-c9c5-11e9-b455-0efb3ba9a670'
     gladier_tools = [
         "gladier_tools.globus.transfer.Transfer:FromStorage",
         BoostCorr,


### PR DESCRIPTION
Make flow fail on exception during boost corr run. 

Remove unused components, related to publishing.

Also maybe noteworthy, I had trouble running with `~` paths on polaris, which complained during execution. Switching those to absolute paths as `/home/nicks/...` fixed this. Not sure if others encountered that too. 